### PR TITLE
castling notation

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -65,6 +65,7 @@ export type ParsedGame = {
 
 /** Parsed move */
 export type ParsedMove = {
+  castle: 'K' | 'Q' | 'k' | 'q' | null
   from: Index
   to: Index
   promotion: PromotionPiece | ''
@@ -112,13 +113,6 @@ export type PositionIndex = {
   a3: 40, b3: 41, c3: 42, d3: 43, e3: 44, f3: 45, g3: 46, h3: 47,
   a2: 48, b2: 49, c2: 50, d2: 51, e2: 52, f2: 53, g2: 54, h2: 55,
   a1: 56, b1: 57, c1: 58, d1: 59, e1: 60, f1: 61, g1: 62, h1: 63,
-}
-
-/** Move notation */
-export type Move = {
-  from: Index
-  to: Index
-  promotion: 'q' | 'r' | 'b' | 'n' | 'Q' | 'R' | 'B' | 'N' | ''
 }
 
 /**

--- a/src/base.ts
+++ b/src/base.ts
@@ -65,7 +65,7 @@ export type ParsedGame = {
 
 /** Parsed move */
 export type ParsedMove = {
-  castle: 'K' | 'Q' | 'k' | 'q' | null
+  castle: 'K' | 'Q' | 'k' | 'q' | false
   from: Index
   to: Index
   promotion: PromotionPiece | ''

--- a/src/game.ts
+++ b/src/game.ts
@@ -412,7 +412,7 @@ export type _IsThreatened<
   Acc extends Index[] = _OccupiedBy<Game, HostileColor>
 > = Acc extends [infer PositionHead extends Index, ...infer PositionTail extends Index[]]
   ? Game['board'][PositionHead] extends FriendlyPiece<HostileColor>
-    ? _CurrentMovesUnsafe<Game, HostileColor, [PositionHead]> extends infer PositionMoves extends Move[]
+    ? _CurrentMovesUnsafe<Game, HostileColor, [PositionHead]> extends infer PositionMoves extends ParsedMove[]
       ? _IsReachable<TargetIndex, PositionMoves> extends true
         ? true
         : _IsThreatened<Game, TargetIndex, HostileColor, PositionTail>
@@ -422,8 +422,8 @@ export type _IsThreatened<
 
 type _IsReachable<
   Target extends Index,
-  Moves extends Move[]
-> = Moves extends [infer Head extends Move, ...infer Tail extends Move[]]
+  Moves extends ParsedMove[]
+> = Moves extends [infer Head extends ParsedMove, ...infer Tail extends ParsedMove[]]
   ? Head['to'] extends Target
     ? true
     : _IsReachable<Target, Tail>

--- a/src/game.ts
+++ b/src/game.ts
@@ -7,7 +7,6 @@ import type {
   Index,
   Indices,
   MaybePiece,
-  Move,
   ParsedGame,
   ParsedMove,
   Piece,
@@ -231,7 +230,7 @@ export type CurrentMovesUnsafe<
   Game extends ParsedGame,
   Turn extends Color = Game['turn'],
   From extends Index[] = _OccupiedBy<Game, Turn>,
-  Acc extends Move[] = []
+  Acc extends ParsedMove[] = []
 > = _CurrentMovesUnsafe<Game, Turn, From, Acc> extends infer M extends Move[]
   ? ToSans<M>
   : never
@@ -240,7 +239,7 @@ export type _CurrentMovesUnsafe<
   Game extends ParsedGame,
   Turn extends Color = Game['turn'],
   From extends Index[] = _OccupiedBy<Game, Turn>,
-  Acc extends Move[] = []
+  Acc extends ParsedMove[] = []
 > = From extends [infer Head extends Index, ...infer Tail extends Index[]]
   ? Game['board'][Head] extends infer CurrentPiece extends Piece
     ? CurrentPiece extends 'p' | 'P' ? _CurrentMovesUnsafe<Game, Turn, Tail, [...Acc, ...PawnMoves<Game, PieceColor<CurrentPiece>, Head>]>

--- a/src/game.ts
+++ b/src/game.ts
@@ -231,7 +231,7 @@ export type CurrentMovesUnsafe<
   Turn extends Color = Game['turn'],
   From extends Index[] = _OccupiedBy<Game, Turn>,
   Acc extends ParsedMove[] = []
-> = _CurrentMovesUnsafe<Game, Turn, From, Acc> extends infer M extends Move[]
+> = _CurrentMovesUnsafe<Game, Turn, From, Acc> extends infer M extends ParsedMove[]
   ? ToSans<M>
   : never
 

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -132,6 +132,7 @@ export type _ParseFen<T extends string> =
 export type ParseSan<T extends string> =
   T extends `${infer FromFile extends File}${infer FromRank extends Rank}${infer ToFile extends File}${infer ToRank extends Rank}${infer Promotion extends PromotionPiece | ''}`
     ? {
+      castle: null,
       from: PositionIndex[`${FromFile}${FromRank}`],
       to: PositionIndex[`${ToFile}${ToRank}`],
       promotion: Promotion extends PromotionPiece ? Promotion : ''

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -138,14 +138,22 @@ export type _ParseFen<T extends string> =
 
 /** Parse move notation */
 export type ParseSan<T extends string> =
-  T extends `${infer FromFile extends File}${infer FromRank extends Rank}${infer ToFile extends File}${infer ToRank extends Rank}${infer Promotion extends PromotionPiece | ''}`
-    ? {
-      castle: false,
-      from: PositionIndex[`${FromFile}${FromRank}`],
-      to: PositionIndex[`${ToFile}${ToRank}`],
-      promotion: Promotion extends PromotionPiece ? Promotion : ''
-    }
-    : never
+  T extends 'O-O'
+    ? { castle: 'K', from: 0, to: 0, promotion: '' }
+    : T extends 'O-O-O'
+      ? { castle: 'Q', from: 0, to: 0, promotion: '' }
+      : T extends 'o-o'
+        ? { castle: 'k', from: 0, to: 0, promotion: '' }
+        : T extends 'o-o-o'
+          ? { castle: 'q', from: 0, to: 0, promotion: '' }
+          : T extends `${infer FromFile extends File}${infer FromRank extends Rank}${infer ToFile extends File}${infer ToRank extends Rank}${infer Promotion extends PromotionPiece | ''}`
+            ? {
+              castle: false,
+              from: PositionIndex[`${FromFile}${FromRank}`],
+              to: PositionIndex[`${ToFile}${ToRank}`],
+              promotion: Promotion extends PromotionPiece ? Promotion : ''
+            }
+            : never
 
 /**
  * Parse a list of moves

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -132,7 +132,7 @@ export type _ParseFen<T extends string> =
 export type ParseSan<T extends string> =
   T extends `${infer FromFile extends File}${infer FromRank extends Rank}${infer ToFile extends File}${infer ToRank extends Rank}${infer Promotion extends PromotionPiece | ''}`
     ? {
-      castle: null,
+      castle: false,
       from: PositionIndex[`${FromFile}${FromRank}`],
       to: PositionIndex[`${ToFile}${ToRank}`],
       promotion: Promotion extends PromotionPiece ? Promotion : ''

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -71,7 +71,15 @@ export type FormatCastling<
 /** format san */
 export type FormatSan<
   T extends ParsedMove,
-> = `${Positions[T['from']]}${Positions[T['to']]}${T['promotion']}`
+> = T['castle'] extends 'K'
+  ? 'O-O'
+  : T['castle'] extends 'Q'
+    ? 'O-O-O'
+    : T['castle'] extends 'k'
+      ? 'o-o'
+      : T['castle'] extends 'q'
+        ? 'o-o-o'
+        : `${Positions[T['from']]}${Positions[T['to']]}${T['promotion']}`
 
 /** Normalize fen board string to a 64 character string */
 export type ParseBoard<
@@ -152,7 +160,7 @@ export type ParseSans<
 /** format tuple of sans */
 export type ToSans<
   T extends ParsedMove[],
-  Acc extends `${Position}${Position}${PromotionPiece | ''}`[] = []
+  Acc extends string[] = []
 > = T extends [infer U extends ParsedMove, ...infer V extends ParsedMove[]]
   ? ToSans<V, [...Acc, FormatSan<U>]>
   : Acc

--- a/src/pieces/pawn.ts
+++ b/src/pieces/pawn.ts
@@ -88,10 +88,10 @@ export type _ExpandPromotions<
   ? Head['to'] extends _PawnPromotionPositions
     ? _ExpandPromotions<Tail, U, [
       ...Acc,
-      { castle: null, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'Q' : 'q' },
-      { castle: null, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'R' : 'r' },
-      { castle: null, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'N' : 'n' },
-      { castle: null, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'B' : 'b' },
+      { castle: false, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'Q' : 'q' },
+      { castle: false, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'R' : 'r' },
+      { castle: false, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'N' : 'n' },
+      { castle: false, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'B' : 'b' },
     ]>
     : _ExpandPromotions<Tail, U, [...Acc, Head]>
   : Acc

--- a/src/pieces/pawn.ts
+++ b/src/pieces/pawn.ts
@@ -88,10 +88,10 @@ export type _ExpandPromotions<
   ? Head['to'] extends _PawnPromotionPositions
     ? _ExpandPromotions<Tail, U, [
       ...Acc,
-      { to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'Q' : 'q' },
-      { to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'R' : 'r' },
-      { to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'N' : 'n' },
-      { to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'B' : 'b' },
+      { castle: null, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'Q' : 'q' },
+      { castle: null, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'R' : 'r' },
+      { castle: null, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'N' : 'n' },
+      { castle: null, to: Head['to'], from: Head['from'], promotion: U extends 'w' ? 'B' : 'b' },
     ]>
     : _ExpandPromotions<Tail, U, [...Acc, Head]>
   : Acc

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export type ToMoves<
   Acc extends unknown[] = []
 > = T extends [infer To extends Index, ...infer Tail extends Index[]]
   ? ToMoves<Tail, From, [...Acc, {
-    castle: null,
+    castle: false,
     from: From,
     to: To,
     promotion: ''

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,5 +42,10 @@ export type ToMoves<
   From extends Index,
   Acc extends unknown[] = []
 > = T extends [infer To extends Index, ...infer Tail extends Index[]]
-  ? ToMoves<Tail, From, [...Acc, { from: From, to: To, promotion: '' }]>
+  ? ToMoves<Tail, From, [...Acc, {
+    castle: null,
+    from: From,
+    to: To,
+    promotion: ''
+  }]>
   : Acc

--- a/tests/game.test-d.ts
+++ b/tests/game.test-d.ts
@@ -390,6 +390,58 @@ describe('IsLegal<Game, San>', () => {
 
     assertType<Result>(false)
   })
+
+  test('cannot castle through check (O-O)', () => {
+    type Result1 = IsLegal<ParseFen<'4r3/8/8/8/8/8/8/4K2R w K - 0 1'>, 'O-O'>
+    type Result2 = IsLegal<ParseFen<'5r2/8/8/8/8/8/8/4K2R w K - 0 1'>, 'O-O'>
+    type Result3 = IsLegal<ParseFen<'6r1/8/8/8/8/8/8/4K2R w K - 0 1'>, 'O-O'>
+    type Result4 = IsLegal<ParseFen<'7r/8/8/8/8/8/8/4K2R w K - 0 1'>, 'O-O'>
+
+    assertType<Result1>(false)
+    assertType<Result2>(false)
+    assertType<Result3>(false)
+    assertType<Result4>(true)
+  })
+
+  test('cannot castle through check (O-O-O)', () => {
+    type Result1 = IsLegal<ParseFen<'4r3/8/8/8/8/8/8/R3K3 w Q - 0 1'>, 'O-O-O'>
+    type Result2 = IsLegal<ParseFen<'3r4/8/8/8/8/8/8/R3K3 w Q - 0 1'>, 'O-O-O'>
+    type Result3 = IsLegal<ParseFen<'2r5/8/8/8/8/8/8/R3K3 w Q - 0 1'>, 'O-O-O'>
+    type Result4 = IsLegal<ParseFen<'1r6/8/8/8/8/8/8/R3K3 w Q - 0 1'>, 'O-O-O'>
+    type Result5 = IsLegal<ParseFen<'r7/8/8/8/8/8/8/R3K3 w Q - 0 1'>, 'O-O-O'>
+
+    assertType<Result1>(false)
+    assertType<Result2>(false)
+    assertType<Result3>(false)
+    assertType<Result4>(false)
+    assertType<Result5>(true)
+  })
+
+  test('cannot castle through check (o-o)', () => {
+    type Result1 = IsLegal<ParseFen<'4k2r/8/8/8/8/8/8/4R3 b k - 0 1'>, 'o-o'>
+    type Result2 = IsLegal<ParseFen<'4k2r/8/8/8/8/8/8/5R2 b k - 0 1'>, 'o-o'>
+    type Result3 = IsLegal<ParseFen<'4k2r/8/8/8/8/8/8/6R1 b k - 0 1'>, 'o-o'>
+    type Result4 = IsLegal<ParseFen<'4k2r/8/8/8/8/8/8/7R b k - 0 1'>, 'o-o'>
+
+    assertType<Result1>(false)
+    assertType<Result2>(false)
+    assertType<Result3>(false)
+    assertType<Result4>(true)
+  })
+
+  test('cannot castle through check (o-o-o)', () => {
+    type Result1 = IsLegal<ParseFen<'r3k3/8/8/8/8/8/8/4R3 b q - 0 1'>, 'o-o-o'>
+    type Result2 = IsLegal<ParseFen<'r3k3/8/8/8/8/8/8/3R4 b q - 0 1'>, 'o-o-o'>
+    type Result3 = IsLegal<ParseFen<'r3k3/8/8/8/8/8/8/2R5 b q - 0 1'>, 'o-o-o'>
+    type Result4 = IsLegal<ParseFen<'r3k3/8/8/8/8/8/8/1R6 b q - 0 1'>, 'o-o-o'>
+    type Result5 = IsLegal<ParseFen<'r3k3/8/8/8/8/8/8/R7 b q - 0 1'>, 'o-o-o'>
+
+    assertType<Result1>(false)
+    assertType<Result2>(false)
+    assertType<Result3>(false)
+    assertType<Result4>(false)
+    assertType<Result5>(true)
+  })
 })
 
 describe('IsThreatened<Game, Color, Index>', () => {

--- a/tests/game.test-d.ts
+++ b/tests/game.test-d.ts
@@ -72,7 +72,7 @@ describe('ApplyMoveUnsafe<Game, San>', () => {
   test('castle white short', () => {
     type Game = ParseFen<'8/8/8/8/8/8/8/4K2R w K - 0 1'>
 
-    type Result = FormatGame<ApplyMoveUnsafe<Game, 'e1g1'>>
+    type Result = FormatGame<ApplyMoveUnsafe<Game, 'O-O'>>
 
     assertType<Result>('8/8/8/8/8/8/8/5RK1 b - - 1 1')
   })
@@ -80,7 +80,7 @@ describe('ApplyMoveUnsafe<Game, San>', () => {
   test('white castle long', () => {
     type Game = ParseFen<'8/8/8/8/8/8/8/R3K3 w Q - 0 1'>
 
-    type Result = FormatGame<ApplyMoveUnsafe<Game, 'e1c1'>>
+    type Result = FormatGame<ApplyMoveUnsafe<Game, 'O-O-O'>>
 
     assertType<Result>('8/8/8/8/8/8/8/2KR4 b - - 1 1')
   })
@@ -88,7 +88,7 @@ describe('ApplyMoveUnsafe<Game, San>', () => {
   test('black castle short', () => {
     type Game = ParseFen<'4k2r/8/8/8/8/8/8/8 b k - 0 1'>
 
-    type Result = FormatGame<ApplyMoveUnsafe<Game, 'e8g8'>>
+    type Result = FormatGame<ApplyMoveUnsafe<Game, 'o-o'>>
 
     assertType<Result>('5rk1/8/8/8/8/8/8/8 w - - 1 2')
   })
@@ -96,7 +96,7 @@ describe('ApplyMoveUnsafe<Game, San>', () => {
   test('black castle long', () => {
     type Game = ParseFen<'r3k3/8/8/8/8/8/8/8 b q - 0 1'>
 
-    type Result = FormatGame<ApplyMoveUnsafe<Game, 'e8c8'>>
+    type Result = FormatGame<ApplyMoveUnsafe<Game, 'o-o-o'>>
 
     assertType<Result>('2kr4/8/8/8/8/8/8/8 w - - 1 2')
   })

--- a/tests/notation.test-d.ts
+++ b/tests/notation.test-d.ts
@@ -309,6 +309,50 @@ describe('ParseSan<T>', () => {
     })
   })
 
+  test('O-O', () => {
+    type Result = ParseSan<'O-O'>
+
+    assertType<Result>({
+      castle: 'K',
+      from: 0,
+      to: 0,
+      promotion: '',
+    })
+  })
+
+  test('O-O-O', () => {
+    type Result = ParseSan<'O-O-O'>
+
+    assertType<Result>({
+      castle: 'Q',
+      from: 0,
+      to: 0,
+      promotion: '',
+    })
+  })
+
+  test('o-o', () => {
+    type Result = ParseSan<'o-o'>
+
+    assertType<Result>({
+      castle: 'k',
+      from: 0,
+      to: 0,
+      promotion: '',
+    })
+  })
+
+  test('o-o-o', () => {
+    type Result = ParseSan<'o-o-o'>
+
+    assertType<Result>({
+      castle: 'q',
+      from: 0,
+      to: 0,
+      promotion: '',
+    })
+  })
+
   test('whoops', () => {
     type Result = ParseSan<'whoops'> extends never ? true : false
 

--- a/tests/notation.test-d.ts
+++ b/tests/notation.test-d.ts
@@ -106,6 +106,50 @@ describe('FormatSan<T>', () => {
 
     assertType<Result>('f5f6')
   })
+
+  test('O-O', () => {
+    type Result = FormatSan<{
+      castle: 'K',
+      from: 0,
+      to: 0,
+      promotion: ''
+    }>
+
+    assertType<Result>('O-O')
+  })
+
+  test('O-O-O', () => {
+    type Result = FormatSan<{
+      castle: 'Q',
+      from: 0,
+      to: 0,
+      promotion: ''
+    }>
+
+    assertType<Result>('O-O-O')
+  })
+
+  test('o-o', () => {
+    type Result = FormatSan<{
+      castle: 'k',
+      from: 0,
+      to: 0,
+      promotion: ''
+    }>
+
+    assertType<Result>('o-o')
+  })
+
+  test('o-o-o', () => {
+    type Result = FormatSan<{
+      castle: 'q',
+      from: 0,
+      to: 0,
+      promotion: ''
+    }>
+
+    assertType<Result>('o-o-o')
+  })
 })
 
 describe('ParseBoard<T>', () => {

--- a/tests/notation.test-d.ts
+++ b/tests/notation.test-d.ts
@@ -87,6 +87,7 @@ describe('FormatGame<T>', () => {
 describe('FormatSan<T>', () => {
   test('a7a8Q', () => {
     type Result = FormatSan<{
+      castle: null,
       from: PositionIndex['a7'],
       to: PositionIndex['a8'],
       promotion: 'Q'
@@ -97,6 +98,7 @@ describe('FormatSan<T>', () => {
 
   test('f5f6', () => {
     type Result = FormatSan<{
+      castle: null,
       from: PositionIndex['f5'],
       to: PositionIndex['f6'],
       promotion: ''
@@ -245,6 +247,7 @@ describe('ParseSan<T>', () => {
     type Result = ParseSan<'e2e4'>
 
     assertType<Result>({
+      castle: null,
       from: 52,
       to: 36,
       promotion: '',
@@ -255,6 +258,7 @@ describe('ParseSan<T>', () => {
     type Result = ParseSan<'a7a8Q'>
 
     assertType<Result>({
+      castle: null,
       from: 8,
       to: 0,
       promotion: 'Q',

--- a/tests/notation.test-d.ts
+++ b/tests/notation.test-d.ts
@@ -87,7 +87,7 @@ describe('FormatGame<T>', () => {
 describe('FormatSan<T>', () => {
   test('a7a8Q', () => {
     type Result = FormatSan<{
-      castle: null,
+      castle: false,
       from: PositionIndex['a7'],
       to: PositionIndex['a8'],
       promotion: 'Q'
@@ -98,7 +98,7 @@ describe('FormatSan<T>', () => {
 
   test('f5f6', () => {
     type Result = FormatSan<{
-      castle: null,
+      castle: false,
       from: PositionIndex['f5'],
       to: PositionIndex['f6'],
       promotion: ''
@@ -247,7 +247,7 @@ describe('ParseSan<T>', () => {
     type Result = ParseSan<'e2e4'>
 
     assertType<Result>({
-      castle: null,
+      castle: false,
       from: 52,
       to: 36,
       promotion: '',
@@ -258,7 +258,7 @@ describe('ParseSan<T>', () => {
     type Result = ParseSan<'a7a8Q'>
 
     assertType<Result>({
-      castle: null,
+      castle: false,
       from: 8,
       to: 0,
       promotion: 'Q',


### PR DESCRIPTION
rather than track to/from positions to identify castling moves, just use the normal notation along with a symble to represent each of the four castling moves